### PR TITLE
Use `/usr/bin/env fab` to find fab executable

### DIFF
--- a/fabric.el
+++ b/fabric.el
@@ -38,7 +38,7 @@
 ;;; Code:
 
 
-(defvar fabric-program "/usr/local/bin/fab" "Fabric binary path.")
+(defvar fabric-program "/usr/bin/env fab" "Fabric binary path.")
 
 (defvar fabric-default-task "-l" "Default task for Fabric.")
 


### PR DESCRIPTION
Using `/usr/bin/env fab` seems like a more robust and reasonable default value for `fabric-program`.
This way you get the fab you have in your activated virtualenv or the fab that's installed on your system.